### PR TITLE
Configurable base API path

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,2 @@
 .git
-node_modules
+**/node_modules

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This service is designed to gather weather data to be used by [IASsure](https://
 
 ## Installation/Deployment
 
-IASsure-WX can be installed using docker. The image is available at `git.fsisp.de/fionn/iassure`.
+IASsure-WX can be installed using docker. The image is available at `git.fsisp.de/fionn/iassure-wx`.
 
 Tags:
   - `latest` - The newest recommended build, built from `main`

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -28,8 +28,24 @@ app.use((err, req: Request, res: Response, next: NextFunction) => {
 nodesched.scheduleJob('regenerate data', '*/30 * * * * *', wxService.wrappedGenerateData)
 wxService.wrappedGenerateData();
 
-app.listen(PORT, () => {
+const server = app.listen(PORT, () => {
   console.log(
     `application is listening on port ${PORT}`,
   );
 });
+
+const shutdown = (signal: string) => {
+  console.log(`${signal} signal received. Shutting down.`);
+  server.close((err) => {
+    if (err) {
+      console.error(`Failed to shut down server gracefully: ${err}`);
+      process.exit(1);
+    }
+
+    console.log('Server closed');
+    process.exit(0);
+  });
+};
+
+process.on('SIGTERM', () => shutdown('SIGTERM'));
+process.on('SIGINT', () => shutdown('SIGINT'));

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -4,14 +4,14 @@ import morgan from 'morgan';
 import router from './router';
 import wxService from './services/wx.service';
 
-const { PORT = 3000 } = process.env;
+const { PORT = 3000, BASE_PATH = '/api' } = process.env;
 
 const app = express();
 
 app.set('trust proxy', true);
 app.use(morgan('combined'));
 
-app.use('/api', router.router);
+app.use(BASE_PATH, router.router);
 
 const frontendRoot = '/opt/frontend/dist';
 app.use(express.static(frontendRoot));


### PR DESCRIPTION
Hi!

Firstly, thanks a lot for setting this up, greatly appreciated, saved me quite a bit of time 😄 

Tiny PR to make the default `/api` base path configurable via env variable to make deployment behind a reverse proxy a bit easier.
I've also added some `SIGTERM`/`SIGINT` handling for a graceful server shutdown (so the process can be `CTRL+C`'d properly and Docker containers shut down without having to be killed).

Thanks again!