### PR TITLE
Make 'trust proxy' option configurable

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -4,11 +4,11 @@ import morgan from 'morgan';
 import router from './router';
 import wxService from './services/wx.service';
 
-const { PORT = 3000, BASE_PATH = '/api' } = process.env;
+const { PORT = 3000, BASE_PATH = '/api', TRUST_PROXY_IP = false } = process.env;
 
 const app = express();
 
-app.set('trust proxy', true);
+app.set('trust proxy', TRUST_PROXY_IP);
 app.use(morgan('combined'));
 
 app.use(BASE_PATH, router.router);


### PR DESCRIPTION
Hi!

Thanks for this cool little app. Appreciate the docker container - makes setting this up real easy! 

I saw that the `trust proxy` option was set to trust every request. The pull request makes this configurable via the `TRUST_PROXY_IP` environment variable (and disables trust proxy by default) so we can be more restrictive when deploying (see http://expressjs.com/en/guide/behind-proxies.html).

Thanks!