### PR TITLE
Fix cronjob syntax for data regeneration

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -32,7 +32,7 @@ app.use((err, req: Request, res: Response, next: NextFunction) => {
   res.status(500).json({ msg: 'an error occurred' });
 });
 
-nodesched.scheduleJob('regenerate data', '*/30 * * * * *', wxService.wrappedGenerateData);
+nodesched.scheduleJob('regenerate data', '*/30 * * * *', wxService.wrappedGenerateData);
 wxService.wrappedGenerateData();
 
 const server = app.listen(config.port, () => {


### PR DESCRIPTION
At the moment, we're re-generating data every 30 seconds instead of every (I assume originally intended) 30 minutes.

Although Open Meteo offers 10000 free API requests per day, both the Belux vACC as well as my private instance are running into rate limits due to the large number of wind variables requests (36 per fix).
Quote from the Open Meteo [pricing page](https://open-meteo.com/en/pricing):

> To calculate the number of API calls accurately, fractional counts are used. For example, 15 weather variables count as 1.5 API calls, while 4 weeks of weather data count as 3.0 API calls.

It looks like `node-schedule` [supports](https://github.com/node-schedule/node-schedule#cron-style-scheduling) 6 instead of 5 parameters with the first one being optional and representing seconds (if provided).

This PR drops the interval from 30 seconds to 30 minutes.